### PR TITLE
Feature/kan 41/calendar local crud

### DIFF
--- a/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
+++ b/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
@@ -1,4 +1,4 @@
-package com.sulsul.core.data.repository.local
+package com.sulsul.core.data.local.repository
 
 import android.util.Log
 import com.sulsul.core.database.dao.DrinkInfoDao
@@ -10,9 +10,10 @@ import com.sulsul.core.model.DrinkRecord
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import java.time.LocalDate
 import javax.inject.Inject
 
-class DrinkRecordRepository @Inject constructor(
+class RecordRepository @Inject constructor(
     private val recordDao: DrinkRecordDao,
     private val drinkInfoDao: DrinkInfoDao,
 ) {
@@ -25,6 +26,28 @@ class DrinkRecordRepository @Inject constructor(
         }
     }
 
+    suspend fun insertRecord(record: DrinkRecord) {
+        val recordId = recordDao.insertRecord(record = record.asEntity()) // 외래키 id 생성
+        insertDrinks(recordId, record.drinks)
+    }
+
+    suspend fun updateDrunkennessLevel(date: LocalDate, state: String) {
+        val drinkRecordEntity = recordDao.getRecordByDate(date) // 날짜에 해당하는 entity를 가져온다
+        drinkRecordEntity.let {
+            it.drunkennessLevel = state // level값만 변경하여
+            recordDao.updateRecord(drinkRecordEntity) // 업데이트 한다 (id 기준 업데이트)
+        }
+    }
+
+    private suspend fun insertDrinks(recordId: Long, drinks: List<DrinkInfo>) {
+        drinks.forEach { drink ->
+            val drinkInfoEntity = drink.asEntity(recordId = recordId.toInt())
+            drinkInfoDao.insertDrinkInfo(drinkInfo = drinkInfoEntity)
+            Log.d("술 데이터 저장", "$recordId, $drinkInfoEntity")
+
+        }
+    }
+
     private fun getDrinkInfoList(recordId: Int): Flow<List<DrinkInfo>> =
         drinkInfoDao.getDrinkInfoListByRecordId(recordId).map { infoList ->
             infoList.map {
@@ -32,16 +55,4 @@ class DrinkRecordRepository @Inject constructor(
             }
         }
 
-    suspend fun addDrinkRecordWithDrinkInfo(record: DrinkRecord) {
-        val recordId = recordDao.insertRecord(record = record.asEntity()) // 외래키 id 생성
-        addDrinkInfo(recordId, record.drinks)
-    }
-
-    private suspend fun addDrinkInfo(recordId: Long, drinkInfoList: List<DrinkInfo>) {
-        drinkInfoList.forEach { info ->
-            val drinkInfoEntity = info.asEntity(recordId.toInt()) // 외래키 설정하여 DrinkInfoEntity 반환
-            drinkInfoDao.insertDrinkInfo(drinkInfo = drinkInfoEntity) // DrinkInfoEntity 삽입
-            Log.d("술 데이터 저장", "$recordId, $drinkInfoEntity")
-        }
-    }
 }

--- a/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
+++ b/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
@@ -52,7 +52,6 @@ class RecordRepository @Inject constructor(
             val drinkInfoEntity = drink.asEntity(recordId = recordId.toInt())
             drinkInfoDao.insertDrinkInfo(drinkInfo = drinkInfoEntity)
             Log.d("술 데이터 저장", "$recordId, $drinkInfoEntity")
-
         }
     }
 
@@ -67,5 +66,4 @@ class RecordRepository @Inject constructor(
         val drinkRecordEntity = recordDao.getRecordByDate(date) // 날짜에 해당하는 entity를 가져온다
         recordDao.deleteRecord(drinkRecordEntity)
     }
-
 }

--- a/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
+++ b/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
@@ -55,4 +55,9 @@ class RecordRepository @Inject constructor(
             }
         }
 
+    suspend fun deleteRecord(date: LocalDate) {
+        val drinkRecordEntity = recordDao.getRecordByDate(date) // 날짜에 해당하는 entity를 가져온다
+        recordDao.deleteRecord(drinkRecordEntity)
+    }
+
 }

--- a/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
+++ b/core/data/src/main/java/com/sulsul/core/data/local/repository/RecordRepository.kt
@@ -31,6 +31,14 @@ class RecordRepository @Inject constructor(
         insertDrinks(recordId, record.drinks)
     }
 
+    suspend fun updateDrinks(recordId: Int, drinks: List<DrinkInfo>) {
+        drinkInfoDao.deleteDrinkInfoByRecordId(recordId)
+        drinks.forEach { drinkInfo ->
+            val drinkInfoEntity = drinkInfo.asEntity(drinkInfo.recordId)
+            drinkInfoDao.insertDrinkInfo(drinkInfoEntity)
+        }
+    }
+
     suspend fun updateDrunkennessLevel(date: LocalDate, state: String) {
         val drinkRecordEntity = recordDao.getRecordByDate(date) // 날짜에 해당하는 entity를 가져온다
         drinkRecordEntity.let {

--- a/core/database/src/main/java/com/sulsul/core/database/dao/DrinkInfoDao.kt
+++ b/core/database/src/main/java/com/sulsul/core/database/dao/DrinkInfoDao.kt
@@ -12,5 +12,5 @@ interface DrinkInfoDao {
     fun getDrinkInfoListByRecordId(recordId: Int): Flow<List<DrinkInfoEntity>>
 
     @Insert
-    fun insertDrinkInfo(drinkInfo: DrinkInfoEntity)
+    suspend fun insertDrinkInfo(drinkInfo: DrinkInfoEntity)
 }

--- a/core/database/src/main/java/com/sulsul/core/database/dao/DrinkInfoDao.kt
+++ b/core/database/src/main/java/com/sulsul/core/database/dao/DrinkInfoDao.kt
@@ -13,4 +13,7 @@ interface DrinkInfoDao {
 
     @Insert
     suspend fun insertDrinkInfo(drinkInfo: DrinkInfoEntity)
+
+    @Query("DELETE FROM record_drink WHERE recordId = :recordId")
+    suspend fun deleteDrinkInfoByRecordId(recordId: Int) // recordId가 동일한 모든 drinkInfo 삭제
 }

--- a/core/database/src/main/java/com/sulsul/core/database/dao/DrinkRecordDao.kt
+++ b/core/database/src/main/java/com/sulsul/core/database/dao/DrinkRecordDao.kt
@@ -1,6 +1,7 @@
 package com.sulsul.core.database.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
@@ -18,6 +19,9 @@ interface DrinkRecordDao {
 
     @Update
     suspend fun updateRecord(record: DrinkRecordEntity)
+
+    @Delete
+    suspend fun deleteRecord(record: DrinkRecordEntity)
 
     @Query("SELECT * FROM record WHERE recordedAt = :date")
     suspend fun getRecordByDate(date: LocalDate): DrinkRecordEntity

--- a/core/database/src/main/java/com/sulsul/core/database/dao/DrinkRecordDao.kt
+++ b/core/database/src/main/java/com/sulsul/core/database/dao/DrinkRecordDao.kt
@@ -3,8 +3,10 @@ package com.sulsul.core.database.dao
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import com.sulsul.core.database.model.DrinkRecordEntity
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 @Dao
 interface DrinkRecordDao {
@@ -12,5 +14,11 @@ interface DrinkRecordDao {
     fun getRecordAll(): Flow<List<DrinkRecordEntity>>
 
     @Insert
-    fun insertRecord(record: DrinkRecordEntity): Long
+    suspend fun insertRecord(record: DrinkRecordEntity): Long
+
+    @Update
+    suspend fun updateRecord(record: DrinkRecordEntity)
+
+    @Query("SELECT * FROM record WHERE recordedAt = :date")
+    suspend fun getRecordByDate(date: LocalDate): DrinkRecordEntity
 }

--- a/core/database/src/main/java/com/sulsul/core/database/model/DrinkInfoEntity.kt
+++ b/core/database/src/main/java/com/sulsul/core/database/model/DrinkInfoEntity.kt
@@ -19,13 +19,12 @@ import com.sulsul.core.model.DrinkInfo
 data class DrinkInfoEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
-    val recordId: Int,
+    val recordId: Int = 0,
     val drinkType: String,
     val quantity: Int
 )
 
 fun DrinkInfoEntity.asExternalModel() = DrinkInfo(
-    recordId = recordId,
     drinkType = drinkType,
     quantity = quantity
 )

--- a/core/database/src/main/java/com/sulsul/core/database/model/DrinkInfoEntity.kt
+++ b/core/database/src/main/java/com/sulsul/core/database/model/DrinkInfoEntity.kt
@@ -25,6 +25,7 @@ data class DrinkInfoEntity(
 )
 
 fun DrinkInfoEntity.asExternalModel() = DrinkInfo(
+    recordId = recordId,
     drinkType = drinkType,
     quantity = quantity
 )

--- a/core/database/src/main/java/com/sulsul/core/database/model/DrinkRecordEntity.kt
+++ b/core/database/src/main/java/com/sulsul/core/database/model/DrinkRecordEntity.kt
@@ -10,17 +10,17 @@ data class DrinkRecordEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val recordedAt: LocalDate,
-    val drunkennessLevel: String
+    var drunkennessLevel: String
 )
 
 fun DrinkRecordEntity.asExternalModel() = DrinkRecord(
-    id = id,
     recordedAt = recordedAt,
     drunkennessLevel = drunkennessLevel,
     drinks = emptyList()
 )
 
 fun DrinkRecord.asEntity() = DrinkRecordEntity(
+    id = id,
     recordedAt = recordedAt,
     drunkennessLevel = drunkennessLevel,
 )

--- a/core/model/src/main/java/com/sulsul/core/model/DrinkRecord.kt
+++ b/core/model/src/main/java/com/sulsul/core/model/DrinkRecord.kt
@@ -8,6 +8,6 @@ import java.time.LocalDate
 data class DrinkRecord(
     val id: Int = 0,
     val recordedAt: LocalDate = LocalDate.now(),
-    val drunkennessLevel: String = "DRUNKEN_DEFAULT",
+    val drunkennessLevel: String = "DRUNKEN_LEVEL_DEFAULT",
     val drinks: List<DrinkInfo> = emptyList()
 ) : Parcelable

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkDialog.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkDialog.kt
@@ -12,13 +12,14 @@ import com.sulsul.feature.calendar.R
 import com.sulsul.feature.calendar.databinding.DialogDrinkBinding
 import com.sulsul.feature.calendar.enums.DrinkTheme
 import com.sulsul.feature.calendar.enums.DrinkUnitRatio
+import com.sulsul.feature.calendar.utils.calculateQuantity
 
 class DrinkDialog(
     private val theme: DrinkTheme,
     private var bottles: Int = 0,
     private var glasses: Int = 0,
     private val onCancelClicked: () -> Unit,
-    private val onSaveClicked: (Int, Int) -> Unit
+    private val onSaveClicked: (Int) -> Unit
 ) : DialogFragment() {
 
     private lateinit var binding: DialogDrinkBinding
@@ -82,7 +83,7 @@ class DrinkDialog(
 
     private fun initClickListeners() {
         binding.tvDialogDrinkSave.setOnClickListener {
-            onSaveClicked(bottles, glasses)
+            onSaveClicked(calculateQuantity(theme.name, bottles, glasses))
             dismiss()
         }
         binding.tvDialogDrinkCancel.setOnClickListener {

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
@@ -107,7 +107,6 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
             Navigation.findNavController(it).navigateUp()
         }
         binding.tvDrinkNext.setOnClickListener {
-
             if (args.drinkRecord.drinks.isEmpty()) {
                 // 상태 선택 화면으로 넘어걸 때 한 번에 저장한다
                 viewModel.insertDrinkRecord(
@@ -140,7 +139,6 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
                 }
             )
             dialog.show(childFragmentManager, "DELETE_DIALOG")
-
         }
     }
 

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.GridLayoutManager
 import com.sulsul.core.common.base.BaseFragment
+import com.sulsul.core.designsystem.view.dialog.TwoButtonDialog
 import com.sulsul.core.model.DrinkInfo
 import com.sulsul.core.model.DrinkRecord
 import com.sulsul.feature.calendar.R
@@ -103,6 +104,22 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
 
             val action = DrinkFragmentDirections.actionDrinkFragmentToDrunkenStateFragment(args.drinkRecord)
             findNavController().navigate(action)
+        }
+
+        binding.tvDrinkDelete.setOnClickListener {
+            val dialog = TwoButtonDialog(
+                title = "삭제",
+                subtitle = "모든 기록을 삭제하시겠습니까?",
+                leftButton = "취소",
+                rightButton = "삭제",
+                onLeftButtonClicked = {},
+                onRightButtonClicked = {
+                    viewModel.deleteDrinkRecord(args.drinkRecord.recordedAt)
+                    Navigation.findNavController(it).navigateUp() // navUp과 pop의 차이가 뭐지?
+                }
+            )
+            dialog.show(childFragmentManager, "DELETE_DIALOG")
+
         }
     }
 

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
@@ -65,13 +65,15 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
                         quantity = calculateQuantity(theme.name, bottles, glasses)
                     )
 
-                    viewModel.addDrinkRecord(
-                        DrinkRecord(
-                            recordedAt = LocalDate.now(),
-                            drunkennessLevel = "DRUNKEN_DEFAULT",
-                            drinks = listOf(data)
-                        )
-                    )
+//                    viewModel.addDrinkRecord(
+//                        DrinkRecord(
+//                            recordedAt = LocalDate.now(),
+//                            drunkennessLevel = "DRUNKEN_DEFAULT",
+//                            drinks = listOf(data)
+//                        )
+//                    )
+
+                    viewModel.drinks.add(data)
 
                     drinkAdapter.notifyDataSetChanged()
                 }
@@ -90,6 +92,15 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
             Navigation.findNavController(it).navigateUp()
         }
         binding.tvDrinkNext.setOnClickListener {
+
+            // 상태 선택 화면으로 넘어걸 때 한 번에 저장한다
+            viewModel.insertDrinkRecord(
+                DrinkRecord(
+                    recordedAt = args.drinkRecord.recordedAt,
+                    drinks = viewModel.drinks
+                )
+            )
+
             val action = DrinkFragmentDirections.actionDrinkFragmentToDrunkenStateFragment(args.drinkRecord)
             findNavController().navigate(action)
         }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkFragment.kt
@@ -41,6 +41,7 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
         super.onViewCreated(view, savedInstanceState)
 
         initDrinkList()
+        initDrinkRecordId()
         initDrinkAdapter()
         initListener()
         setToolbarTitle()
@@ -64,6 +65,7 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
                         viewModel.drinks.remove(removedDrink)
                     } else {
                         val drink = DrinkInfo(
+                            recordId = viewModel.recordId,
                             drinkType = theme.name,
                             quantity = quantity
                         )
@@ -94,19 +96,32 @@ class DrinkFragment : BaseFragment<FragmentDrinkBinding>() {
         }
     }
 
+    private fun initDrinkRecordId() {
+        if (args.drinkRecord.drinks.isNotEmpty()) {
+            viewModel.recordId = args.drinkRecord.drinks[0].recordId
+        }
+    }
+
     private fun initListener() {
         binding.btnDrinkBack.setOnClickListener {
             Navigation.findNavController(it).navigateUp()
         }
         binding.tvDrinkNext.setOnClickListener {
 
-            // 상태 선택 화면으로 넘어걸 때 한 번에 저장한다
-            viewModel.insertDrinkRecord(
-                DrinkRecord(
-                    recordedAt = args.drinkRecord.recordedAt,
-                    drinks = viewModel.drinks
+            if (args.drinkRecord.drinks.isEmpty()) {
+                // 상태 선택 화면으로 넘어걸 때 한 번에 저장한다
+                viewModel.insertDrinkRecord(
+                    DrinkRecord(
+                        recordedAt = args.drinkRecord.recordedAt,
+                        drinks = viewModel.drinks
+                    )
                 )
-            )
+            } else {
+                viewModel.updateDrinks(
+                    viewModel.drinks[0].recordId,
+                    viewModel.drinks
+                )
+            }
 
             val action = DrinkFragmentDirections.actionDrinkFragmentToDrunkenStateFragment(args.drinkRecord)
             findNavController().navigate(action)

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
@@ -2,7 +2,8 @@ package com.sulsul.feature.calendar.drink
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.sulsul.core.data.repository.local.DrinkRecordRepository
+import com.sulsul.core.data.local.repository.RecordRepository
+import com.sulsul.core.model.DrinkInfo
 import com.sulsul.core.model.DrinkRecord
 import com.sulsul.feature.calendar.enums.DrinkTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,7 +13,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class DrinkViewModel @Inject constructor(
-    private val repository: DrinkRecordRepository
+    private val repository: RecordRepository
 ) : ViewModel() {
 
     val drinkThemeList = listOf(
@@ -27,9 +28,11 @@ class DrinkViewModel @Inject constructor(
         DrinkTheme.SAKE
     )
 
-    fun addDrinkRecord(data: DrinkRecord) {
+    val drinks = mutableListOf<DrinkInfo>()
+
+    fun insertDrinkRecord(record: DrinkRecord) {
         viewModelScope.launch(Dispatchers.IO) {
-            repository.addDrinkRecordWithDrinkInfo(data)
+            repository.insertRecord(record)
         }
     }
 }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
@@ -9,6 +9,7 @@ import com.sulsul.feature.calendar.enums.DrinkTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -33,6 +34,12 @@ class DrinkViewModel @Inject constructor(
     fun insertDrinkRecord(record: DrinkRecord) {
         viewModelScope.launch(Dispatchers.IO) {
             repository.insertRecord(record)
+        }
+    }
+
+    fun deleteDrinkRecord(date: LocalDate) {
+        viewModelScope.launch(Dispatchers.IO) {
+            repository.deleteRecord(date)
         }
     }
 }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
@@ -30,6 +30,7 @@ class DrinkViewModel @Inject constructor(
     )
 
     var drinks = mutableListOf<DrinkInfo>()
+    var recordId = 0
 
     fun insertDrinkRecord(record: DrinkRecord) {
         viewModelScope.launch(Dispatchers.IO) {
@@ -40,6 +41,12 @@ class DrinkViewModel @Inject constructor(
     fun deleteDrinkRecord(date: LocalDate) {
         viewModelScope.launch(Dispatchers.IO) {
             repository.deleteRecord(date)
+        }
+    }
+
+    fun updateDrinks(recordId: Int, drinks: List<DrinkInfo>) {
+        viewModelScope.launch(Dispatchers.IO) {
+            repository.updateDrinks(recordId, drinks)
         }
     }
 }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/DrinkViewModel.kt
@@ -29,7 +29,7 @@ class DrinkViewModel @Inject constructor(
         DrinkTheme.SAKE
     )
 
-    val drinks = mutableListOf<DrinkInfo>()
+    var drinks = mutableListOf<DrinkInfo>()
 
     fun insertDrinkRecord(record: DrinkRecord) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/adapter/DrinkAdapter.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/adapter/DrinkAdapter.kt
@@ -1,6 +1,5 @@
 package com.sulsul.feature.calendar.drink.adapter
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/adapter/DrinkAdapter.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/drink/adapter/DrinkAdapter.kt
@@ -1,5 +1,6 @@
 package com.sulsul.feature.calendar.drink.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -11,9 +12,10 @@ import com.sulsul.feature.calendar.utils.splitQuantity
 
 class DrinkAdapter(
     private val drinkThemeList: List<DrinkTheme>,
-    private val drinkInfoList: List<DrinkInfo>,
     private val onClicked: (drinkTheme: DrinkTheme, bottles: Int, glasses: Int) -> Unit
 ) : RecyclerView.Adapter<DrinkAdapter.DrinkViewHolder>() {
+
+    private var drinkInfoList: List<DrinkInfo> = emptyList()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DrinkViewHolder {
         val binding =
@@ -34,6 +36,7 @@ class DrinkAdapter(
             with(binding) {
                 var bottles = 0
                 var glasses = 0
+                var isSelected = false
 
                 containerDrinkItem.setBackgroundResource(theme.backgroundColor)
                 ivDrinkItem.setBackgroundResource(theme.selectorImage)
@@ -42,19 +45,25 @@ class DrinkAdapter(
 
                 drinkInfoList
                     .filter { it.drinkType == theme.name }
-                    .forEach {
-                        val drinkText = buildDrinkText(it.drinkType, it.quantity)
-                        bottles = splitQuantity(theme.name, it.quantity).first
-                        glasses = splitQuantity(theme.name, it.quantity).second
+                    .forEach { lastDrinkInfo ->
+                        val drinkText = buildDrinkText(lastDrinkInfo.drinkType, lastDrinkInfo.quantity)
+                        bottles = splitQuantity(theme.name, lastDrinkInfo.quantity).first
+                        glasses = splitQuantity(theme.name, lastDrinkInfo.quantity).second
 
                         tvDrinkItem.text = drinkText
-                        containerDrinkItem.isSelected = true
+                        isSelected = true
                     }
+
+                containerDrinkItem.isSelected = isSelected
 
                 containerDrinkItem.setOnClickListener {
                     onClicked(theme, bottles, glasses)
                 }
             }
         }
+    }
+
+    fun setDrinks(drinks: List<DrinkInfo>) {
+        drinkInfoList = drinks
     }
 }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/enums/DrinkUnitRatio.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/enums/DrinkUnitRatio.kt
@@ -5,9 +5,9 @@ enum class DrinkUnitRatio(val glassPerBottle: Int?) {
     BEER(3),
     SOJUBEER(null),
     WINE(5),
-    RICE_WINE(3),
+    RICE_WINE(5),
     COCKTAIL(null),
     WHISKY(25),
     VODKA(25),
-    SAKE(6)
+    SAKE(7)
 }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/enums/DrunkenStateTheme.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/enums/DrunkenStateTheme.kt
@@ -4,7 +4,7 @@ enum class DrunkenStateTheme(
     val icon: Int,
     val whale: Int,
 ) {
-    DRUNKEN_DEFAULT(
+    DRUNKEN_LEVEL_DEFAULT(
         icon = com.sulsul.core.designsystem.R.drawable.ic_drunken_state_default,
         whale = com.sulsul.core.designsystem.R.drawable.img_drunken_whale_empty
     ),

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/CalendarFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/CalendarFragment.kt
@@ -21,14 +21,13 @@ class CalendarFragment : BaseFragment<FragmentCalendarBinding>() {
 
     private lateinit var calendarAdapter: CalendarAdapter
     private val viewModel: CalenderViewModel by activityViewModels()
-    private var pageIndex: Int = 0
 
     override fun getFragmentBinding(
         inflater: LayoutInflater,
         container: ViewGroup?,
     ): FragmentCalendarBinding {
         arguments?.let {
-            pageIndex = it.getInt("pageIndex", 0)
+            viewModel.pageIndex = it.getInt("pageIndex", 0)
         }
         return FragmentCalendarBinding.inflate(inflater, container, false)
     }
@@ -49,12 +48,12 @@ class CalendarFragment : BaseFragment<FragmentCalendarBinding>() {
 
     private fun initCalendar(data: List<DrinkRecord>) {
         val dayOfWeeks = resources.getStringArray(R.array.calendar_day_of_weeks).toList()
-        pageIndex -= (Int.MAX_VALUE / 2)
-        calendarAdapter = CalendarAdapter(dayOfWeeks, data) { date, infoList ->
+        viewModel.pageIndex -= (Int.MAX_VALUE / 2)
+        calendarAdapter = CalendarAdapter(dayOfWeeks, data) { date, record ->
             viewModel.setDate(date)
-            viewModel.setDrinkInfoList(infoList)
+            viewModel.setRecord(record)
         }
-        calendarAdapter.calendarManager.setSelectedMonth(pageIndex)
+        calendarAdapter.calendarManager.setSelectedMonth(viewModel.pageIndex)
 
         binding.rvCalendar.apply {
             this.adapter = calendarAdapter

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/CalenderViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/CalenderViewModel.kt
@@ -1,6 +1,8 @@
 package com.sulsul.feature.calendar.main
 
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sulsul.core.data.local.repository.RecordRepository
@@ -34,6 +36,11 @@ class CalenderViewModel @Inject constructor(
     private val _drinkRecord = MutableStateFlow<DrinkRecord>(DrinkRecord())
     val drinkRecord: StateFlow<DrinkRecord> = _drinkRecord
 
+    var pageIndex = 0
+
+    private var _isLoaded = MutableLiveData(false)
+    val isLoaded: LiveData<Boolean> = _isLoaded
+
     init {
         getDrinkRecords()
     }
@@ -44,16 +51,17 @@ class CalenderViewModel @Inject constructor(
         _calendarMonth.value = currentDate.monthValue
     }
 
-    fun getDrinkRecords() {
+    private fun getDrinkRecords() {
         viewModelScope.launch {
             repository.getRecordAll().collect { records ->
                 _drinkRecordList.value = records
                 Log.d("###", "$records")
+                _isLoaded.value = true
             }
         }
     }
 
-    fun setDrinkInfoList(drinkRecord: DrinkRecord) {
+    fun setRecord(drinkRecord: DrinkRecord) {
         _drinkRecord.value = drinkRecord
     }
 

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/CalenderViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/CalenderViewModel.kt
@@ -1,9 +1,9 @@
 package com.sulsul.feature.calendar.main
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.sulsul.core.data.repository.local.DrinkRecordRepository
-import com.sulsul.core.model.DrinkInfo
+import com.sulsul.core.data.local.repository.RecordRepository
 import com.sulsul.core.model.DrinkRecord
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CalenderViewModel @Inject constructor(
-    private val repository: DrinkRecordRepository,
+    private val repository: RecordRepository,
 ) : ViewModel() {
 
     private val calendarDate = LocalDate.now()
@@ -46,53 +46,10 @@ class CalenderViewModel @Inject constructor(
 
     fun getDrinkRecords() {
         viewModelScope.launch {
-//            repository.getRecordAll().collect { records ->
-//                _drinkRecordList.value = records
-//            }
-
-            val records = listOf(
-                DrinkRecord(
-                    id = 1,
-                    recordedAt = LocalDate.of(2024, 4, 1),
-                    drunkennessLevel = "DRUNKEN_LEVEL_4",
-                    drinks = listOf(
-                        DrinkInfo(
-                            recordId = 1,
-                            drinkType = "SOJU",
-                            quantity = 21
-                        ),
-                        DrinkInfo(
-                            recordId = 1,
-                            drinkType = "SOJUBEER",
-                            quantity = 10
-                        ),
-                        DrinkInfo(
-                            recordId = 1,
-                            drinkType = "RICE_WINE",
-                            quantity = 3
-                        )
-                    )
-                ),
-                DrinkRecord(
-                    id = 2,
-                    recordedAt = LocalDate.of(2024, 4, 2),
-                    drunkennessLevel = "DRUNKEN_LEVEL_3",
-                    drinks = listOf(
-                        DrinkInfo(
-                            recordId = 2,
-                            drinkType = "SAKE",
-                            quantity = 22
-                        ),
-                        DrinkInfo(
-                            recordId = 2,
-                            drinkType = "SOJUBEER",
-                            quantity = 10
-                        )
-                    )
-                ),
-
-            )
-            _drinkRecordList.value = records
+            repository.getRecordAll().collect { records ->
+                _drinkRecordList.value = records
+                Log.d("###", "$records")
+            }
         }
     }
 

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/MainFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/MainFragment.kt
@@ -13,9 +13,9 @@ import com.sulsul.core.common.base.BaseFragment
 import com.sulsul.core.model.DrinkInfo
 import com.sulsul.feature.calendar.R
 import com.sulsul.feature.calendar.databinding.FragmentMainBinding
-import com.sulsul.feature.calendar.main.adapter.DrinkRankAdapter.Companion.TOP_RANK
 import com.sulsul.feature.calendar.main.adapter.CalendarPagerAdapter
 import com.sulsul.feature.calendar.main.adapter.DrinkRankAdapter
+import com.sulsul.feature.calendar.main.adapter.DrinkRankAdapter.Companion.TOP_RANK
 import com.sulsul.feature.calendar.utils.formatDateToString
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -35,7 +35,6 @@ class MainFragment : BaseFragment<FragmentMainBinding>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initPagerCalendar()
         initObserver()
         initListener()
     }
@@ -116,6 +115,12 @@ class MainFragment : BaseFragment<FragmentMainBinding>() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.selectedDate.collect { date ->
                 binding.tvCalendarDateLabel.text = formatDateToString(date)
+            }
+        }
+
+        viewModel.isLoaded.observe(viewLifecycleOwner) {
+            if (it) {
+                initPagerCalendar()
             }
         }
     }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/adapter/CalendarAdapter.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/main/adapter/CalendarAdapter.kt
@@ -23,6 +23,8 @@ class CalendarAdapter(
     private val curYear = curDate.year
     private val curMonth = curDate.month
 
+    private var selectedPosition: Int = RecyclerView.NO_POSITION
+
     val calendarManager = CalendarManager()
 
     companion object {
@@ -100,6 +102,7 @@ class CalendarAdapter(
 
             bindDate(date)
             bindStateImage(date, records)
+            bindItemClickListener(date, records)
         }
 
         private fun bindDate(date: Int) {
@@ -113,19 +116,39 @@ class CalendarAdapter(
         }
 
         private fun bindStateImage(date: Int, records: List<DrinkRecord>) {
+            if (selectedPosition == adapterPosition) {
+                setSelected(true)
+            } else {
+                setSelected(false)
+            }
+
             val record = records.firstOrNull { isSameDate(it.recordedAt, date) }
             record?.let {
                 val icon = getDrunkenStateTheme(it.drunkennessLevel).icon
                 binding.ivCalendarItemState.setImageResource(icon)
             }
+        }
 
+        private fun bindItemClickListener(date: Int, records: List<DrinkRecord>) {
+            val record = records.firstOrNull { isSameDate(it.recordedAt, date) }
             binding.ivCalendarItemState.setOnClickListener {
+                selectedPosition = adapterPosition
+                notifyDataSetChanged()
+
                 val selectedDate = calendarManager.getSelectedDate(date)
 
                 onClicked(
                     selectedDate,
                     record ?: DrinkRecord(recordedAt = selectedDate)
                 )
+            }
+        }
+
+        private fun setSelected(isSelected: Boolean) {
+            if (isSelected) {
+                binding.ivCalendarItemState.setBackgroundResource(R.drawable.bg_blue300_circle)
+            } else {
+                binding.ivCalendarItemState.setBackgroundResource(0)
             }
         }
     }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateFragment.kt
@@ -4,17 +4,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.navigation.Navigation
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.sulsul.core.common.base.BaseFragment
+import com.sulsul.feature.calendar.R
 import com.sulsul.feature.calendar.databinding.FragmentDrunkenStateBinding
 import com.sulsul.feature.calendar.enums.DrunkenStateTheme
 import com.sulsul.feature.calendar.utils.formatDateToString
 import com.sulsul.feature.calendar.utils.getDrunkenStateTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class DrunkenStateFragment : BaseFragment<FragmentDrunkenStateBinding>() {
 
     private val args: DrunkenStateFragmentArgs by navArgs()
+    private val viewModel: DrunkenStateViewModel by viewModels()
     override fun getFragmentBinding(
         inflater: LayoutInflater,
         container: ViewGroup?
@@ -37,22 +43,32 @@ class DrunkenStateFragment : BaseFragment<FragmentDrunkenStateBinding>() {
 
         binding.ivDrunkenStateIcon1.setOnClickListener {
             setDrunkenStateView(DrunkenStateTheme.DRUNKEN_LEVEL_1)
+            viewModel.state = DrunkenStateTheme.DRUNKEN_LEVEL_1.name
         }
 
         binding.ivDrunkenStateIcon2.setOnClickListener {
             setDrunkenStateView(DrunkenStateTheme.DRUNKEN_LEVEL_2)
+            viewModel.state = DrunkenStateTheme.DRUNKEN_LEVEL_2.name
         }
 
         binding.ivDrunkenStateIcon3.setOnClickListener {
             setDrunkenStateView(DrunkenStateTheme.DRUNKEN_LEVEL_3)
+            viewModel.state = DrunkenStateTheme.DRUNKEN_LEVEL_3.name
         }
 
         binding.ivDrunkenStateIcon4.setOnClickListener {
             setDrunkenStateView(DrunkenStateTheme.DRUNKEN_LEVEL_4)
+            viewModel.state = DrunkenStateTheme.DRUNKEN_LEVEL_4.name
         }
 
         binding.ivDrunkenStateIcon5.setOnClickListener {
             setDrunkenStateView(DrunkenStateTheme.DRUNKEN_LEVEL_5)
+            viewModel.state = DrunkenStateTheme.DRUNKEN_LEVEL_5.name
+        }
+
+        binding.tvDrunkenStateSave.setOnClickListener {
+            viewModel.updateStatus(args.drinkRecord.recordedAt, viewModel.state)
+            findNavController().popBackStack(R.id.mainFragment, false)
         }
     }
 
@@ -72,74 +88,6 @@ class DrunkenStateFragment : BaseFragment<FragmentDrunkenStateBinding>() {
 
             ivDrunkenStateWhale.setImageResource(value.whale)
         }
-//        when (value) {
-//            DrunkenStateTheme.DRUNKEN_LEVEL_1 -> {
-//                with(binding) {
-//                    ivDrunkenStateBubble1.visibility = View.VISIBLE
-//                    ivDrunkenStateBubble2.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble3.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble4.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble5.visibility = View.INVISIBLE
-//
-//                    ivDrunkenStateWhale.setImageResource(value.whale)
-//                }
-//            }
-//            DrunkenStateTheme.DRUNKEN_LEVEL_2 -> {
-//                with(binding) {
-//                    ivDrunkenStateBubble1.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble2.visibility = View.VISIBLE
-//                    ivDrunkenStateBubble3.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble4.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble5.visibility = View.INVISIBLE
-//
-//                    ivDrunkenStateWhale.setImageResource(value.whale)
-//                }
-//            }
-//            DrunkenStateTheme.DRUNKEN_LEVEL_3 -> {
-//                with(binding) {
-//                    ivDrunkenStateBubble1.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble2.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble3.visibility = View.VISIBLE
-//                    ivDrunkenStateBubble4.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble5.visibility = View.INVISIBLE
-//
-//                    ivDrunkenStateWhale.setImageResource(value.whale)
-//                }
-//            }
-//            DrunkenStateTheme.DRUNKEN_LEVEL_4 -> {
-//                with(binding) {
-//                    ivDrunkenStateBubble1.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble2.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble3.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble4.visibility = View.VISIBLE
-//                    ivDrunkenStateBubble5.visibility = View.INVISIBLE
-//
-//                    ivDrunkenStateWhale.setImageResource(value.whale)
-//                }
-//            }
-//            DrunkenStateTheme.DRUNKEN_LEVEL_5 -> {
-//                with(binding) {
-//                    ivDrunkenStateBubble1.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble2.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble3.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble4.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble5.visibility = View.VISIBLE
-//
-//                    ivDrunkenStateWhale.setImageResource(value.whale)
-//                }
-//            }
-//            else -> {
-//                with(binding) {
-//                    ivDrunkenStateBubble1.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble2.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble3.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble4.visibility = View.INVISIBLE
-//                    ivDrunkenStateBubble5.visibility = View.INVISIBLE
-//
-//                    ivDrunkenStateWhale.setImageResource(DrunkenStateTheme.DRUNKEN_DEFAULT.whale)
-//                }
-//            }
-//        }
     }
 
     private fun setToolbarTitle() {

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateFragment.kt
@@ -32,8 +32,13 @@ class DrunkenStateFragment : BaseFragment<FragmentDrunkenStateBinding>() {
         super.onViewCreated(view, savedInstanceState)
 
         setToolbarTitle()
+        initState()
         initListener()
         setDrunkenStateView(getDrunkenStateTheme(args.drinkRecord.drunkennessLevel))
+    }
+
+    private fun initState() {
+        viewModel.state = args.drinkRecord.drunkennessLevel
     }
 
     private fun initListener() {

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateFragment.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateFragment.kt
@@ -72,7 +72,10 @@ class DrunkenStateFragment : BaseFragment<FragmentDrunkenStateBinding>() {
         }
 
         binding.tvDrunkenStateSave.setOnClickListener {
-            viewModel.updateStatus(args.drinkRecord.recordedAt, viewModel.state)
+            if (args.drinkRecord.drunkennessLevel != viewModel.state) {
+                viewModel.updateStatus(args.drinkRecord.recordedAt, viewModel.state)
+            }
+
             findNavController().popBackStack(R.id.mainFragment, false)
         }
     }

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateViewModel.kt
@@ -1,0 +1,24 @@
+package com.sulsul.feature.calendar.state
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sulsul.core.data.local.repository.RecordRepository
+import com.sulsul.feature.calendar.enums.DrunkenStateTheme
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class DrunkenStateViewModel @Inject constructor(
+    private val repository: RecordRepository
+): ViewModel() {
+
+    var state = DrunkenStateTheme.DRUNKEN_LEVEL_DEFAULT.name
+    fun updateStatus(date: LocalDate, level: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            repository.updateDrunkennessLevel(date, level)
+        }
+    }
+}

--- a/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateViewModel.kt
+++ b/feature/calendar/src/main/java/com/sulsul/feature/calendar/state/DrunkenStateViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class DrunkenStateViewModel @Inject constructor(
     private val repository: RecordRepository
-): ViewModel() {
+) : ViewModel() {
 
     var state = DrunkenStateTheme.DRUNKEN_LEVEL_DEFAULT.name
     fun updateStatus(date: LocalDate, level: String) {

--- a/feature/calendar/src/main/res/layout/item_date_with_image.xml
+++ b/feature/calendar/src/main/res/layout/item_date_with_image.xml
@@ -22,6 +22,7 @@
         android:id="@+id/iv_calendar_item_state"
         android:layout_width="34dp"
         android:layout_height="34dp"
+        android:padding="1dp"
         android:src="@drawable/ic_drunken_state_empty"
         app:layout_constraintEnd_toEndOf="@id/tv_calendar_item_small_date"
         app:layout_constraintStart_toStartOf="@id/tv_calendar_item_small_date"


### PR DESCRIPTION
## 💡 Issue
- [KAN-41](https://team-sulsul.atlassian.net/browse/KAN-41)

## 🌱Key Changes
- 술 기록 저장 및 업데이트 로직 구현
- 날짜에 해당하는 데이터 삭제 구현
- 선택한 날짜 표시 기능 구현

## 📷ScreenShot
[calendar_local_crud.webm](https://github.com/team-sulsul/sulsul-android/assets/110798031/708ec723-c801-48eb-bd2f-bd677d46975a)


## ✅ To Reviewers
[버그]
- 선택한 날짜를 주변에 파란색 테두리로 표시하게 되는데, 엉뚱한 날짜에 오늘 날짜로 체크되는 버그가 있습니다
- 월을 변경 후 해당 월 날짜 클릭 -> 이전 월로 이동 시 이전에 선택했던 표시(파란색 테두리)가 남아있는 문제가 있습니다
- 다음 스프린트에 수정하도록 하겠습니다.

[기능 미구현]
- 캘린더 화면으로 최초 진입 시, 술 기록을 저장하고 캘린더 화면으로 이동 시 하단의 술 랭크 뷰가 업데이트 되지 않고 있습니다
- 다음 스프린트에 구현할 예정입니다

[:data 모듈 패기지 구조 변경 제안]
- 이전에 제안했던 패키지 구조는 repository 안에서 local, remote로 분기하는 것입니다. 하지만 이런 구조로 가게 될 경우 model, mapper 등 데이터 레이어에 들어가는 패키지마다 local, remote로 분기해야합니다.
```
core
  └── data
      ├── repository
      │   ├── local
      │   │  └── RecordRepository.kt
          └── remote
```

새로 제안하는 구조는 초반에 local remote로 나눈 뒤 각각 repositroy, mapper 등으로 나누는 것입니다. 현재 작업한 코드는 아래와 같은 패키지 구조로 변경한 상태이며 다른 의견 있으면 언제든지 얘기해주세요~
```
core
  └── data
      ├── local
      │   └── repository
      │       └── RecordRepository.kt
      └── remote
          ├── mapper
          ├── model
          └── repository
```

[디자이너와의 의견 조율]
- 삭제 다이얼로그의 문구는 제가 임의로 정했기 때문에 디자이너와의 내용 조율 필요합니다
- 선택한 날짜 표시(파란 테두리)의 경우 개인적인 판단으로 구현했기 때문에 디자이너와의 소통 필요합니다

[KAN-41]: https://team-sulsul.atlassian.net/browse/KAN-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ